### PR TITLE
修复 TypeError: issubclass() arg 1 must be a class

### DIFF
--- a/nonebot/plugin.py
+++ b/nonebot/plugin.py
@@ -377,7 +377,8 @@ def on_command(
             raise TypeError('the name of a command must be a str or tuple')
         if not name:
             raise ValueError('the name of a command must not be empty')
-        if not issubclass(session_implement, CommandSession):
+        if session_implement is not None and not issubclass(
+                session_implement, CommandSession):
             raise TypeError(
                 'session_implement must be a subclass of CommandSession')
 


### PR DESCRIPTION
在master分支合并 #206 后出现该错误
```
Traceback (most recent call last):
  File "main.py", line 17, in <module>
    async def _(session: CommandSession):
  File "/home/vsonline/workspace/nonebot/.venv/lib/python3.8/site-packages/nonebot-1.6.0-py3.8.egg/nonebot/plugin.py", line 380, in deco
    if not issubclass(session_implement, CommandSession):
TypeError: issubclass() arg 1 must be a class
```
测试用例
```python
from nonebot import on_command, CommandSession


class NewSession(CommandSession):

    async def send(self, message: str, *args, **kwargs):
        message += '\nWonderful Impl!'
        await super().send(message, *args, **kwargs)


@on_command('test', session_implement=NewSession)
async def _(session: NewSession):
    await session.send('Testing!')


@on_command('normal_test')
async def _(session: CommandSession):
    await session.send('Normal Testing!')


if __name__ == "__main__":
    import nonebot
    nonebot.init()
    nonebot.run(host='127.0.0.1', port=8080)
```