### PR TITLE
Add straight forward asynchronous operation for CommandSession

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,10 @@ sidebar: auto
 
 # 更新日志
 
+## master
+
+- `CommandSession` 新增 `aget` `apause` 方法， 用于 Session 的异步获取参数
+
 ## v1.7.0
 
 - `on_command` 装饰器新增 `patterns` 参数，用于正则匹配命令

--- a/nonebot/command/__init__.py
+++ b/nonebot/command/__init__.py
@@ -3,8 +3,8 @@ import asyncio
 import warnings
 from datetime import datetime
 from functools import partial
-from typing import (Tuple, Union, Iterable, Any, Optional, List, Dict,
-                    Awaitable, Pattern, NoReturn, Type)
+from typing import (NoReturn, Tuple, Union, Iterable, Any, Optional, List, Dict,
+                    Awaitable, Pattern, Type)
 
 from aiocqhttp import Event as CQEvent
 from aiocqhttp.message import Message
@@ -164,7 +164,7 @@ class CommandManager:
     @classmethod
     def add_command(cls, cmd_name: CommandName_T, cmd: Command) -> None:
         """Register a command
-
+        
         Args:
             cmd_name (CommandName_T): Command name
             cmd (Command): Command object
@@ -178,9 +178,9 @@ class CommandManager:
     @classmethod
     def reload_command(cls, cmd_name: CommandName_T, cmd: Command) -> None:
         """Reload a command
-
+        
         **Warning! Dangerous function**
-
+        
         Args:
             cmd_name (CommandName_T): Command name
             cmd (Command): Command object
@@ -201,12 +201,12 @@ class CommandManager:
     @classmethod
     def remove_command(cls, cmd_name: CommandName_T) -> bool:
         """Remove a command
-
+        
         **Warning! Dangerous function**
-
+        
         Args:
             cmd_name (CommandName_T): Command name to remove
-
+        
         Returns:
             bool: Success or not
         """
@@ -227,7 +227,7 @@ class CommandManager:
                               cmd_name: CommandName_T,
                               state: Optional[bool] = None):
         """Change command state globally or simply switch it if `state` is None
-
+        
         Args:
             cmd_name (CommandName_T): Command name
             state (Optional[bool]): State to change to. Defaults to None.
@@ -239,7 +239,7 @@ class CommandManager:
     @classmethod
     def add_aliases(cls, aliases: Union[Iterable[str], str], cmd: Command):
         """Register command alias(es)
-
+        
         Args:
             aliases (Union[Iterable[str], str]): Command aliases
             cmd (Command): Command
@@ -280,7 +280,7 @@ class CommandManager:
     def _add_command_to_tree(self, cmd_name: CommandName_T, cmd: Command,
                              tree: Dict[str, Union[Dict, Command]]) -> None:
         """Add command to the target command tree.
-
+        
         Args:
             cmd_name (CommandName_T): Name of the command
             cmd (Command): Command object
@@ -303,10 +303,10 @@ class CommandManager:
         self, commands: Dict[CommandName_T,
                              Command]) -> Dict[str, Union[Dict, Command]]:
         """Generate command tree from commands dictionary.
-
+        
         Args:
             commands (Dict[CommandName_T, Command]): Dictionary of commands
-
+        
         Returns:
             Dict[str, Union[Dict, "Command"]]: Command tree
         """
@@ -433,7 +433,7 @@ class CommandManager:
                        cmd_name: CommandName_T,
                        state: Optional[bool] = None):
         """Change command state or simply switch it if `state` is None
-
+        
         Args:
             cmd_name (CommandName_T): Command name
             state (Optional[bool]): State to change to. Defaults to None.
@@ -696,7 +696,7 @@ class CommandSession(BaseSession):
         if message:
             self._run_future(self.send(message, **kwargs))
         if not self.waiting:
-            self._future = asyncio.Future()
+            self._future = asyncio.get_event_loop().create_future()
             self.running = False
             res = await self._future
             self.running = True

--- a/nonebot/command/__init__.py
+++ b/nonebot/command/__init__.py
@@ -26,7 +26,7 @@ class CommandInterrupt(Exception):
     pass
 
 
-class _YieldException(Exception):
+class _YieldException(CommandInterrupt):
     """
     Raised by command.run(), session indicating that the waiting session
     will resume and current execution path should return immediately.

--- a/nonebot/command/__init__.py
+++ b/nonebot/command/__init__.py
@@ -641,10 +641,11 @@ class CommandSession(BaseSession):
         self.pause(prompt, **kwargs)
 
     async def aget(self,
-                   key: str,
+                   key: str = ...,
                    *,
                    prompt: Optional[Message_T] = None,
                    arg_filters: Optional[List[Filter_T]] = None,
+                   force_update: bool = ...,
                    **kwargs) -> Any:
         """
         Get an argument with a given key.
@@ -659,8 +660,13 @@ class CommandSession(BaseSession):
         :param arg_filters: argument filters for the next user input
         :return: the argument value
         """
+        if key is ... and force_update is ...:
+            force_update = True
         if key in self.state:
-            return self.state[key]
+            if force_update:
+                del self.state[key]
+            else:
+                return self.state[key]
 
         self.current_key = key
         self.current_arg_filters = arg_filters


### PR DESCRIPTION
CommandSession.aget()
CommandSession.apause()
will pause the session asynchronously and wait till next wakeup

Example Code:

```python
@nonebot.on_command("test")
async def test_command(session: nonebot.CommandSession):
    def validate_digit(x):
        if x in list('0123456789'):
            return int(x)
        else:
            raise ValidateError("???Input a digit:")

    def validate_string(x):
        if len(x) > 5:
            return x
        else:
            raise ValidateError("???Input a string (len > 5):")

    number = await session.aget('number', prompt='Input a digit:', arg_filters=[validate_digit])
    string = await session.aget('str', prompt='Input a string (len > 5):', arg_filters=[validate_string])
    # Do something
    session.finish(f'Get number and string: {number} {string}')

```