### PR TITLE
Deal with apause() call that takes longer than session timeout. …

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,7 @@ sidebar: auto
 
 ## master
 - 手工创建的 `Plugin` 对象现在会对传递的集合参数进行浅拷贝
+- 修复 `CommandSession.apause` 方法在命令过期后泄露的问题
 
 ## v1.8.1
 

--- a/nonebot/command/__init__.py
+++ b/nonebot/command/__init__.py
@@ -667,11 +667,14 @@ class CommandSession(BaseSession):
             try:
                 self._future = asyncio.get_event_loop().create_future()
                 self.running = False
-                await self._future
+                timeout = None
+                if self.bot.config.SESSION_EXPIRE_TIMEOUT:
+                    timeout = self.bot.config.SESSION_EXPIRE_TIMEOUT.total_seconds()
+                await asyncio.wait_for(self._future, timeout)
                 break
             except _PauseException:
                 continue
-            except _FinishException:
+            except (_FinishException, asyncio.TimeoutError):
                 raise
 
     def finish(self, message: Optional[Message_T] = None, **kwargs) -> NoReturn:


### PR DESCRIPTION
…the caller has to interrupt the task and finish the session