### PR TITLE
添加 @on_shutdown

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -803,6 +803,22 @@ sidebar: auto
 
   注册启动时回调，初始化数据库。
 
+### _decorator_ `on_shutdown`
+
+- **说明:**
+
+  将函数装饰为 NoneBot 关闭时的回调函数。
+
+- **用法:**
+
+  ```python
+  @on_shutdown
+  async def shutdown()
+      await db.close_connections()
+  ```
+
+  注册退出时的回调，关闭数据库连接。
+
 ### _decorator_ `on_websocket_connect` <Badge text="1.5.0+"/>
 
 - **说明:**

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,10 @@ sidebar: auto
 
 # 更新日志
 
+## master
+
+- 新增 `nonebot.on_shutdown` 装饰器，用于注册 NoneBot 停止时回调函数
+
 ## v1.9.1
 
 - 修复上版本更新带来的 `on_command` 定义命令别名有时不生效的 bug

--- a/nonebot/__init__.py
+++ b/nonebot/__init__.py
@@ -126,6 +126,14 @@ def on_startup(func: Callable[[], Awaitable[None]]) \
     return get_bot().server_app.before_serving(func)
 
 
+def on_shutdown(func: Callable[[], Awaitable[None]]) \
+        -> Callable[[], Awaitable[None]]:
+    """
+    Decorator to register a function as shutdown callback.
+    """
+    return get_bot().server_app.after_serving(func)
+
+
 def on_websocket_connect(func: Callable[[aiocqhttp.Event], Awaitable[None]]) \
         -> Callable[[], Awaitable[None]]:
     """
@@ -154,6 +162,7 @@ __all__ = [
     'get_bot',
     'run',
     'on_startup',
+    'on_shutdown',
     'on_websocket_connect',
     'CQHttpError',
     'load_plugin',


### PR DESCRIPTION
现在只有 `@on_startup`，没有 `@on_shutdown`，想在机器人关闭的时候，关闭数据库或者浏览器，还要把 Quart 揪出来。